### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/cruztyree0030784/4d32e9c0-0e49-435b-ab26-227f97c8c858/de422e41-be47-4b78-970a-9ff192204c87/_apis/work/boardbadge/7f749a2f-b011-445b-a1b8-170897504013)](https://dev.azure.com/cruztyree0030784/4d32e9c0-0e49-435b-ab26-227f97c8c858/_boards/board/t/de422e41-be47-4b78-970a-9ff192204c87/Microsoft.RequirementCategory)
 opam2web
 ========
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cruztyree0030784/4d32e9c0-0e49-435b-ab26-227f97c8c858/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.